### PR TITLE
Add two unit tests to fully cover the WarBot class.

### DIFF
--- a/tests/WarBotTest.php
+++ b/tests/WarBotTest.php
@@ -2,7 +2,10 @@
 
 namespace WarBot\Tests;
 
+use WarBot\Actions\CreateGraphAction;
 use WarBot\Actions\SendMessageAction;
+use WarBot\Models\Method;
+use WarBot\Models\Subject;
 use WarBot\Repositories\MethodRepository;
 use WarBot\Repositories\SubjectRepository;
 use WarBot\WarBot;
@@ -30,5 +33,52 @@ class WarBotTest extends WarBotTestCase
             $message = $this->container->get(WarBot::class)->handle();
             echo $message . "\n\n";
         } while ($message !== null);
+    }
+
+    public function testNoWar()
+    {
+        // Setup a subject repository mock with only one subject to fetch.
+        $subject_repository = $this->createMock(SubjectRepository::class);
+        $subject_repository->expects($this->once())->method('getAlive')->willReturn([new Subject(1,'name1')]);
+
+        // Setup some shell mocks strictly to instantiate WarBot.
+        $method_repository = $this->createMock(MethodRepository::class);
+        $create_graph_action = $this->createMock(CreateGraphAction::class);
+        $send_message_action = $this->createMock(SendMessageAction::class);
+
+        $warbot = new WarBot($subject_repository, $send_message_action, $create_graph_action, $method_repository);
+
+        // The response should be null.
+        self::assertNull($warbot->handle());
+    }
+
+    /** @test */
+    public function testWarWithTwoUsers()
+    {
+        // Setup a subject repository mock with two subjects to fetch.
+        // asserting that we do kill off a subject.
+        $subject_repository = $this->createMock(SubjectRepository::class);
+        $subject_repository->expects($this->once())->method('getAlive')->willReturn([new Subject(1,'name1'), new Subject(1,'name2')]);
+        $subject_repository->expects($this->once())->method('kill')->with(self::isInstanceOf(Subject::class));
+
+        // Setup a method repository to provide a kill method.
+        $method_repository = $this->createMock(MethodRepository::class);
+        $method_repository->method('getOne')->willReturn(new Method('with a knife'));
+
+        // Setup a graph action to return a graph image path.
+        $create_graph_action = $this->createMock(CreateGraphAction::class);
+        $create_graph_action->expects(self::once())->method('handle')->willReturn('images/sweetgraph.jpg');
+
+        // Setup a send message action to assert the message after the round states we have one participant left.
+        // and also assert that our provided image path was also provided.
+        $send_message_action = $this->createMock(SendMessageAction::class);
+        $send_message_action->expects($this->once())->method('handle')->with(
+            self::stringContains("and there's 1 participant left"),
+            self::stringContains("images/sweetgraph.jpg")
+        );
+
+        // Instantiate WarBot with mocks to exercise 3 assertions.
+        $warbot = new WarBot($subject_repository, $send_message_action, $create_graph_action, $method_repository);
+        $warbot->handle();
     }
 }


### PR DESCRIPTION
This adds two unit tests to fully cover the WarBot class itself address Issue #2 . 
It's worth noting that when unit test code spends more time mocking then testing, the code may need to be cleaned up a bit.
![Screen Shot 2020-10-07 at 5 55 16 PM](https://user-images.githubusercontent.com/6137941/95399979-ae8daf80-08c6-11eb-9ba1-938a5b523d3d.png)
![Screen Shot 2020-10-07 at 5 55 26 PM](https://user-images.githubusercontent.com/6137941/95399977-ad5c8280-08c6-11eb-96bb-aadd9a071e70.png)

- The Action classes new up concrete classes so those will need to be functionally modified before they can be tested. At the very lest, we should be able to set the TwitterOAuth connection or even fetch it from the config repository (factory)instead of creating it new. Same goes for instantiating the Image class in CreateGraphAction.
- The Model classes are value objects with public properties so they don't need to be tested. 
- The Repository classes should have their path be set-able so fixtures can be offered instead of the concrete paths which would make testing easier. 

Cheers.   
Happy #Hacktoberfest